### PR TITLE
Infrastructure Alerts for New Relic Broker

### DIFF
--- a/src/main/java/com/libertymutualgroup/herman/nr/broker/services/AlertConfigurationService.java
+++ b/src/main/java/com/libertymutualgroup/herman/nr/broker/services/AlertConfigurationService.java
@@ -54,7 +54,7 @@ public class AlertConfigurationService {
                 ArrayNode infrastructureAlertsConditions = getInfrastructureAlertsConditions(configuration);
 
                 Assert.isTrue(
-                    applicationAlertsConditions != null || rdsPluginAlertsConditions != null || nrqlAlertsConditions != null,
+                    applicationAlertsConditions != null || rdsPluginAlertsConditions != null || nrqlAlertsConditions != null || infrastructureAlertsConditions != null,
                     "There are no alerts conditions defined");
 
                 // Delete existing policies and channels


### PR DESCRIPTION
- Adding missing logic to allow NR Broker to only create infrastructure alerts

Fixes: https://github.com/libertymutual/herman-newrelic-broker/issues/1